### PR TITLE
Reimplemented jit

### DIFF
--- a/cbits/buffer.c
+++ b/cbits/buffer.c
@@ -34,3 +34,9 @@ void buffer_to_host_buffer__event_await(PJRT_Api *api, PJRT_Buffer *src, PJRT_Bu
     API_CALL_CATCHER(Event_Await, fatal_error, .event = event);
     API_CALL_CATCHER(Event_Destroy, fatal_error, .event = event);
 }
+
+const int64_t *buffer_dimensions(PJRT_Api *api, PJRT_Buffer *buffer, size_t *rank_out) {
+    auto result = API_CALL_CATCHER(Buffer_Dimensions, fatal_error, .buffer = buffer);
+    *rank_out = result.num_dims;
+    return result.dims;
+}

--- a/src/HAX/PjRt.hs
+++ b/src/HAX/PjRt.hs
@@ -83,6 +83,10 @@ bufferToHostBuffer (Buffer b) =
   withForeignPtr b $ \ b' -> 
     C.bufferToHostBuffer api b'
 
+bufferDimensions :: Buffer -> IO [Int64]
+bufferDimensions (Buffer b) =
+  withForeignPtr b $ \ b' ->
+    C.bufferDimensions api b'
 
 -- Event
 eventAwait :: Event -> IO ()

--- a/src/HAX/PjRt/Buffer.hs
+++ b/src/HAX/PjRt/Buffer.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnliftedFFITypes #-}
-{-# LANGUAGE ViewPatterns #-}
 module HAX.PjRt.Buffer (
 --  bufferDestroy 
   bufferDestroy__ptr
 , bufferToHostBuffer
+, bufferDimensions
 ) where
 
 import HAX.PjRt.Plugin
@@ -32,3 +32,12 @@ bufferToHostBuffer api buffer = do
   MutableByteArray dst# <- newByteArray $ fromIntegral dstSize
   c__bufferToHostBuffer__eventAwait api buffer nullPtr dst# dstSize 
   unsafeFreezeByteArray (MutableByteArray dst#)
+
+foreign import ccall unsafe "buffer_dimensions"
+  c__bufferDimensions :: Ptr Api -> Ptr Buffer -> Ptr CSize -> IO (Ptr Int64)
+bufferDimensions :: Ptr Api -> Ptr Buffer -> IO [Int64]
+bufferDimensions api buffer = do 
+  alloca $ \ size -> do
+    dims <- c__bufferDimensions api buffer size 
+    _size <- peek size 
+    peekArray (fromIntegral _size) dims

--- a/src/HAX/Target.hs
+++ b/src/HAX/Target.hs
@@ -6,11 +6,14 @@
 module HAX.Target where
 import HAX.Tensor.Tracer
 import HAX.Tensor.Tensorial
+import HAX.Tensor.Tensor
 
 import HAX.AD.Gradient
 import HAX.AD.Reverse
 import HAX.AD
 
+
+import HAX.Jit
 import HAX.Utils
 
 import Control.Exception
@@ -247,3 +250,5 @@ instance (ReverseMode (a -> f), Cotangent (r s t)) => ReverseMode (Target (Rever
   type GradResult (Target (Reverse r) s t -> a -> f) = Target r s t <+> GradResult (a -> f)
   rgrad' (g, i) f (Target dim t) = assert (null dim) $ rgrad' (g, i + 1) (f $ Target [] $ Reverse (t, independent i))
   rgradReify (Annotated idx) (reifyGrad idx -> (g, g')) = Target [] g :+: rgradReify (Annotated (idx + 1) :: Annotated CIntPtr (a -> f)) g'
+
+type instance JitTransform (Target r s t) = Tensor s t

--- a/src/HAX/Tensor.hs
+++ b/src/HAX/Tensor.hs
@@ -2,12 +2,10 @@
 module HAX.Tensor (
   module Tensorial
 , module Tracer
--- , module Target
 , module Tensor
 ) where
 
-import HAX.Tensor.Tensor    as Tensor
+import HAX.Tensor.Tensor    as Tensor hiding (jit)
 import HAX.Tensor.Tracer    as Tracer
--- import HAX.Tensor.Target    as Target
 import HAX.Tensor.Tensorial as Tensorial
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,6 +8,7 @@ import HAX.PjRt
 import HAX.AD
 import HAX.AD.Reverse
 import HAX.Target
+import HAX.Jit
 
 import Data.Proxy
 
@@ -126,6 +127,24 @@ main = do
 
   traceDebug     test4
   traceDebugGrad test20
+
+  let a :: Tensor '[4, 5] Float = 
+        [[ 1, 2, 3, 4, 5], 
+         [-1,-2,-3,-4,-5],
+         [ 6,-2, 5, 9,-1],
+         [-7, 3, 2, 8, 6]]
+      b :: Tensor '[5, 1] Float = 
+        [[1],[2],[3],[4],[5]]
+      c = matmul a b
+
+  print =<< debugTensorShape c
+  print c
+  let d :: Tensor '[4, 1] Float = [[1], [2], [3], [4]]
+  print d
+
+
+  let e = jit test10
+  print $ e 1
 
   clientDestroy client
   return ()


### PR DESCRIPTION
jit is now extendable to other traceable functions, including one taking targets.
the output function no longer determines the input function. 